### PR TITLE
feat: add GET/POST tweets api on main page

### DIFF
--- a/src/apis/authorization.js
+++ b/src/apis/authorization.js
@@ -2,7 +2,7 @@ import { apiHelper } from './../utils/helpers'
 
 export default {
   // 帶入需要的參數
-  loginIn ({ account, password }) {
+  loginIn({ account, password }) {
     // 這裡 return 的會是一個 Promise
     return apiHelper.post('/users/signin', {
       account,

--- a/src/apis/tweet.js
+++ b/src/apis/tweet.js
@@ -1,0 +1,16 @@
+import { apiHelper } from './../utils/helpers'
+const getToken = () => localStorage.getItem('token')
+
+
+export default {
+  getTweets() {
+    return apiHelper.get('/tweets', {
+      headers: { Authorization: `Bearer ${getToken()}` }
+    })
+  },
+  postTweet(content) {
+    return apiHelper.post('/tweets', {"description": `${content}`}, {
+      headers: { Authorization: `Bearer ${getToken()}` }
+    })
+  }
+}

--- a/src/assets/css/basic.css
+++ b/src/assets/css/basic.css
@@ -75,6 +75,10 @@
   border-radius: 50px;
 }
 
+/* when button is disabled */
+button[disabled] {
+  opacity: 0.5;
+}
 
 /* form */
 .form-input {
@@ -231,11 +235,11 @@
 }
 
 .col,
-.col-6 {
+.col-7 {
   height: 100vh;
 }
 
-.col-6 {
+.col-7 {
   border-left: 1px solid #E6ECF0;
   border-right: 1px solid #E6ECF0;
 }

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -28,7 +28,7 @@
       class="btn-bg btn-border w-100"
       :disabled="isProcessing"
     >
-      登入
+      {{ isProcessing ? "處理中..." : "登入" }}
     </button>
   </form>
 </template>
@@ -66,22 +66,21 @@ export default {
           account: this.user.account,
           password: this.user.password,
         });
-
+        
         // 取得 API 請求後的資料
         const data = response.data;
 
-        if (data.status !== "success") {
+        if (data.status === "error") {
           throw new Error(data.message);
         }
 
-        // ⚠️ TODO：等後端更新路由後修改為 data.token
-        localStorage.setItem("token", data.data.token);
+        localStorage.setItem("token", data.token);
 
-        // 成功登入後轉址
         Toast.fire({
           icon: "success",
           title: "登入成功",
         });
+        // 成功登入後轉址
         this.$router.push("/main");
       } catch (error) {
         this.isProcessing = false;
@@ -93,7 +92,8 @@ export default {
         this.user.password = "";
       }
     },
-};
+  }
+}
 </script>
 
 <style scoped>
@@ -111,10 +111,6 @@ button {
   padding: 8px 158px 8px 158px;
   background-color: var(--main-color);
   cursor: pointer;
-}
-
-button[disabled] {
-  opacity: 0.5;
 }
 
 .form-input:nth-child(2) {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -4,27 +4,27 @@
       <div class="nav-logo"></div>
       <ul class="nav-list">
         <li class="nav-item">
-          <router-link to="/main" class="nav-link active">
+          <router-link to="/main" class="nav-link">
             <div class="nav-icon home-icon"></div>
             <span class="nav-title">首頁</span>
           </router-link>
         </li>
         <li class="nav-item">
-          <a href="#" class="nav-link">
+          <router-link to="#" class="nav-link">
             <div class="nav-icon person-icon"></div>
             <span class="nav-title">個人資料</span>
-          </a>
+          </router-link>
         </li>
         <li class="nav-item">
-          <a href="#" class="nav-link">
+          <router-link to="/setting" class="nav-link">
             <div class="nav-icon setting-icon"></div>
             <span class="nav-title">設定</span>
-          </a>
+          </router-link>
         </li>
       </ul>
       <button
         class="add-tweet-btn btn-bg btn-border btn-50"
-        @click.stop.prevent="showModal(true)"
+        @click.stop.prevent="showTweetModal(true)"
       >
         推文
       </button>
@@ -46,9 +46,9 @@
 export default {
   name: "Sidebar",
   methods: {
-    showModal(bool) {
-      // 通知 Main.vue 要開啟 modal
-      this.$emit("show-modal", bool);
+    showTweetModal(bool) {
+      // 通知 Main.vue or Reply.vue 要開啟 tweet modal
+      this.$emit("show-tweet-modal", bool);
     },
   },
 };
@@ -107,6 +107,7 @@ export default {
 }
 
 .add-tweet-btn {
+  max-width: 11.1rem;
   height: 2.875rem;
   padding: 0.5rem 1.5rem;
 }

--- a/src/components/TweetCard.vue
+++ b/src/components/TweetCard.vue
@@ -1,93 +1,36 @@
 <template>
-  <!-- Tweet cards list -->
-  <div class="card-container">
-    <div class="card-tweet">
-      <div class="user-image-sm"></div>
-      <div class="card-info">
-        <div class="card-header">
-          <div class="user-naming">
-            <p class="user-name">Apple</p>
-            <p class="user-handle">
-              @applepen<span>・</span><span class="time-stamp">3 小時</span>
-            </p>
-          </div>
-        </div>
-        <div class="card-body">
-          <p class="tweet-content">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-            Pellentesque interdum rutrum sodales. Nullam mattis fermentum
-            libero, non volutpat.
+  <div class="card-tweet">
+    <img
+      class="user-image-sm"
+      :src="tweet.User.avatar | emptyImage"
+      alt="user-image"
+    />
+    <div class="card-info">
+      <div class="card-header">
+        <div class="user-naming">
+          <p class="user-name">{{ tweet.User.name }}</p>
+          <p class="user-handle">
+            @{{ tweet.User.account }}<span>・</span
+            ><span class="time-stamp">{{ tweet.createdAt | fromNow }}</span>
           </p>
-        </div>
-        <div class="card-footer">
-          <div class="icon-section">
-            <div class="footer-icon reply-icon"></div>
-            <span class="counter reply-count">13</span>
-          </div>
-          <div class="icon-section">
-            <div class="footer-icon like-icon"></div>
-            <span class="counter like-count">76</span>
-          </div>
         </div>
       </div>
-    </div>
-    <div class="card-tweet">
-      <div class="user-image-sm"></div>
-      <div class="card-info">
-        <div class="card-header">
-          <div class="user-naming">
-            <p class="user-name">Apple</p>
-            <p class="user-handle">
-              @applepen<span>・</span><span class="time-stamp">3 小時</span>
-            </p>
-          </div>
-        </div>
-        <div class="card-body">
-          <p class="tweet-content">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-            Pellentesque interdum rutrum sodales. Nullam mattis fermentum
-            libero, non volutpat.
-          </p>
-        </div>
-        <div class="card-footer">
-          <div class="icon-section">
-            <div class="footer-icon reply-icon"></div>
-            <span class="counter reply-count">13</span>
-          </div>
-          <div class="icon-section">
-            <div class="footer-icon like-icon"></div>
-            <span class="counter like-count">76</span>
-          </div>
-        </div>
+      <div class="card-body">
+        <p class="tweet-content">
+          {{ tweet.description }}
+        </p>
       </div>
-    </div>
-    <div class="card-tweet">
-      <div class="user-image-sm"></div>
-      <div class="card-info">
-        <div class="card-header">
-          <div class="user-naming">
-            <p class="user-name">Apple</p>
-            <p class="user-handle">
-              @applepen<span>・</span><span class="time-stamp">3 小時</span>
-            </p>
-          </div>
+      <div class="card-footer">
+        <div class="icon-section">
+          <div
+          class="footer-icon reply-icon"
+          @click.stop.prevent="showReplyModal(true)"
+          ></div>
+          <span class="counter reply-count">{{ tweet.repliesCounts }}</span>
         </div>
-        <div class="card-body">
-          <p class="tweet-content">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-            Pellentesque interdum rutrum sodales. Nullam mattis fermentum
-            libero, non volutpat.
-          </p>
-        </div>
-        <div class="card-footer">
-          <div class="icon-section">
-            <div class="footer-icon reply-icon"></div>
-            <span class="counter reply-count">13</span>
-          </div>
-          <div class="icon-section">
-            <div class="footer-icon like-icon"></div>
-            <span class="counter like-count">76</span>
-          </div>
+        <div class="icon-section">
+          <div class="footer-icon like-icon"></div>
+          <span class="counter like-count">{{ tweet.likesCounts }}</span>
         </div>
       </div>
     </div>
@@ -95,57 +38,27 @@
 </template>
 
 <script>
-const dummyData = {
-  data: {
-    user: {
-      id: 270,
-      name: "user3",
-      introduction: "hello,Nice to meet you",
-      avatar: null,
-      banner: null,
-    },
-    currentUser: {
-      id: 272,
-      account: "user5",
-      name: "user5",
-      email: "user5@example.com",
-      avatar: null,
-      introduction: null,
-      banner: null,
-      role: "user",
-      createdAt: "2022-07-27T05:06:05.000Z",
-      updatedAt: "2022-07-28T15:18:16.000Z",
-      Followers: [],
-      Followings: [],
+import { emptyImageFilter } from "../utils/mixins";
+import { fromNowFilter } from "../utils/mixins"
+
+export default {
+  name: "TweetCard",
+  mixins: [emptyImageFilter, fromNowFilter],
+  props: {
+    initialTweet: {
+      type: Object,
+      required: true,
     },
   },
-};
-export default {
   data() {
     return {
-      currentUser: {},
-      user: {
-        id: 0,
-        account: "",
-        name: "",
-        introduction: "",
-        avatar: "",
-        banner: "",
-        tweetCount: 0,
-        followingCount: 0,
-        followerCount: 0,
-        likeCount: 0,
-        isFollowed: false,
-      },
+      tweet: this.initialTweet,
     };
   },
-  created() {
-    this.fetchUser();
-  },
   methods: {
-    fetchUser() {
-      this.currentUser = dummyData.data.currentUser;
-      this.user = dummyData.data.user;
+    showReplyModal(bool) {
+      // 通知 Main.vue or Reply.vue 要開啟 reply modal
+      this.$emit("show-reply-modal", bool);
     },
   },
 };
@@ -160,11 +73,7 @@ export default {
 }
 
 .user-image-sm {
-  padding: 1rem;
   margin-right: 0.5rem;
-  background-image: url("./../assets/pictures/dummyUser.png");
-  background-size: contain;
-  background-repeat: no-repeat;
 }
 
 .card-info {
@@ -193,16 +102,5 @@ export default {
 
 .like-icon {
   background-image: url("./../assets/pictures/like.png");
-}
-
-.icon-section:hover {
-  filter: brightness(0) saturate(100%) invert(38%) sepia(52%) saturate(2219%)
-    hue-rotate(2deg) brightness(107%) contrast(105%);
-}
-
-.counter {
-  color: var(--secondary-color);
-  font-size: 0.875rem;
-  font-weight: 600;
 }
 </style>

--- a/src/components/TweetDetail.vue
+++ b/src/components/TweetDetail.vue
@@ -31,7 +31,7 @@
   border-bottom: 1px solid var(--page-divider);
 }
 
-/* tweet header: user name & handle */
+/* tweet header: user name, handle and image */
 .tweet-header {
   display: flex;
   align-items: center;
@@ -96,6 +96,12 @@
   cursor: pointer;
 }
 
+/* disable filter setting from basic.css */
+.icon-section:hover {
+  filter: none;
+}
+
+/* add individual icon filter setting */
 .footer-icon:hover {
   filter: brightness(0) saturate(100%) invert(38%) sepia(52%) saturate(2219%)
     hue-rotate(2deg) brightness(107%) contrast(105%);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,12 +4,6 @@ import Vuex from 'vuex'
 Vue.use(Vuex)
 Vue.config.devtools = true
 
-export const store = new Vuex.Store({
-  state: {
-    counter: 0
-  }
-})
-
 export default new Vuex.Store({
   // data
   state: {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -4,7 +4,8 @@ import 'sweetalert2/src/sweetalert2.scss'
 
 import axios from 'axios'
 
-const baseURL = 'https://simpletwitter-2206.herokuapp.com/api'
+// 🚨 heroku 尚未建置完成，先以 localhost 替代
+const baseURL = 'http://localhost:3000/api'
 
 export const apiHelper = axios.create({
   baseURL

--- a/src/utils/mixins.js
+++ b/src/utils/mixins.js
@@ -2,7 +2,7 @@ import moment from "moment"
 export const emptyImageFilter = {
   filters: {
     emptyImage (src) {
-      return src || 'https://via.placeholder.com/350x220/DFDFDF?text=No+Image'
+      return src || require('../assets/pictures/dummyUser.png')
     }
   }
 }

--- a/src/views/AccountSetting.vue
+++ b/src/views/AccountSetting.vue
@@ -4,7 +4,7 @@
       <div class="col-3">
         <Sidebar />
       </div>
-      <div class="col-6">
+      <div class="col-7">
         <h4>帳戶設定</h4>
         <hr />
         <form

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -2,13 +2,22 @@
   <div class="container">
     <div class="row">
       <div class="col">
-        <SideBar @show-modal="toggleTweetModal(true)" />
+        <SideBar @show-tweet-modal="toggleTweetModal(true)" />
       </div>
-      <div class="col-6 scrollable-part">
+      <div class="col-7 scrollable-part">
         <h4 class="main-title">首頁</h4>
-        <CreateTweet />
+        <CreateTweet
+        @after-tweet-submit="afterTweetSubmit"
+        />
         <div class="divider"></div>
-        <TweetCard />
+        <div class="card-container">
+          <TweetCard
+            v-for="tweet in allTweets"
+            :key="tweet.id"
+            :initial-tweet="tweet"
+            @show-reply-modal="toggleReplyModal(true)"
+          />
+        </div>
       </div>
       <div class="col">
         <PopularUsers />
@@ -25,14 +34,17 @@ import PopularUsers from "../components/PopularUsers";
 import TweetModal from "../components/TweetModal";
 import CreateTweet from "../components/CreateTweet";
 import TweetCard from "../components/TweetCard";
-import ReplyModal from "../components/ReplyModal"
+import ReplyModal from "../components/ReplyModal";
+import tweetsAPI from "../apis/tweet";
+import { Toast } from "./../utils/helpers";
 
 export default {
   name: "Main",
   data() {
     return {
       showTweetModal: false,
-      showReplyModal: false
+      showReplyModal: false,
+      allTweets: [],
     };
   },
   components: {
@@ -41,7 +53,10 @@ export default {
     TweetModal,
     CreateTweet,
     TweetCard,
-    ReplyModal
+    ReplyModal,
+  },
+  created() {
+    this.fetchTweets();
   },
   methods: {
     toggleTweetModal(bool) {
@@ -49,6 +64,26 @@ export default {
     },
     toggleReplyModal(bool) {
       this.showReplyModal = bool;
+    },
+    async fetchTweets() {
+      try {
+        const response = await tweetsAPI.getTweets();
+
+        this.allTweets = response.data;
+
+        if (response.data.status === "error") {
+          throw new Error(response.data.message);
+        }
+      } catch (error) {
+        console.error(error);
+        Toast.fire({
+          icon: "error",
+          title: "無法取得所有推文，請稍後再試",
+        });
+      }
+    },
+    afterTweetSubmit() {
+      this.fetchTweets();
     }
   },
 };
@@ -82,12 +117,12 @@ export default {
 }
 
 .scrollable-part::-webkit-scrollbar {
-  background-color: #FAFAFA;
+  background-color: #fafafa;
   width: 15px;
 }
 
 .scrollable-part::-webkit-scrollbar-thumb {
-  background-color: #C1C1C1;
+  background-color: #c1c1c1;
   border-radius: 4px;
 }
 </style>

--- a/src/views/Reply.vue
+++ b/src/views/Reply.vue
@@ -2,15 +2,17 @@
   <div class="container">
     <div class="row">
       <div class="col">
-        <SideBar @show-modal="toggleTweetModal(true)" />
+        <SideBar @show-tweet-modal="toggleTweetModal(true)" />
       </div>
-      <div class="col-6 scrollable-part">
+      <div class="col-7 scrollable-part">
         <div class="main-title">
+          <router-link to="/main">
           <img
             :src="require('../assets/pictures/prev.png')"
             class="prev-icon"
             alt="..."
           />
+          </router-link>
           <h4>推文</h4>
         </div>
         <TweetDetail />

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -4,7 +4,7 @@
       <div class="col">
           <SideBar />
       </div>
-      <div class="col-6">
+      <div class="col-7">
         <UserProfileCard />
       </div>
       <div class="col">

--- a/src/views/UserFollows.vue
+++ b/src/views/UserFollows.vue
@@ -4,7 +4,7 @@
       <div class="col">
         <SideBar />
       </div>
-      <div class="col-6 scrollable-part">
+      <div class="col-7 scrollable-part">
         <div class="main-title">
           <img
             :src="require('../assets/pictures/prev.png')"


### PR DESCRIPTION
## 本次更新
### 畫面
- basic.css：新增 button[disabled] 樣式，禁用按鈕時會改變透明度
- 固定 Sidebar 推文按鈕寬度，並調整頁面中間區塊的欄寬，由 col-6 改為 col-7
- Sidebar 圖示現在會依所在頁面改變顏色（⚠️尚未設定個人資料的 router-link）
- 修正 TweetDetail 游標 hover 到圖示上，兩個圖案會同時變色的問題
- 更改 emptyImageFilter 的預設圖片
- 點擊 reply icon 可彈出回覆視窗

### 功能
- ⚠️ 因後端 heroku 尚未建置完成，helpers.js 的 baseURL 暫時以 localhost 代替
- 新增 tweet.js api 檔
- 再次修正註冊、登入功能，新增帳號超過 20 字的錯誤提示
- 串接 POST /api/tweets，可在 Main.vue 的 CreateTweet.vue 新增推文
- 串接 GET /api/tweets，可在 Main.vue 瀏覽所有推文

[註冊 -> 發出推文] 預覽動畫
![loginToPostATweet](https://user-images.githubusercontent.com/72937427/182559955-eb2ad080-bea4-43f7-87b4-80aea7e5abd2.gif)

